### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ them here, so that in the future this repo might serve as the base for learning 
 
 ### Using this resource
 
-This resource presumes ALOT of prerequisite knowledge in it's users.
+This resource presumes A LOT of prerequisite knowledge in its users.
 1. You kinda know what Erlang concurrency and OTP is about/why it's good. If you've yet to
    drink the Kool-aid, allow me to provide some:
   [The Soul of Erlang and Elixir talk](https://www.youtube.com/watch?v=JvBT4XBdoUE)
@@ -31,7 +31,7 @@ This resource presumes ALOT of prerequisite knowledge in it's users.
    to learn. If you have never seen Gleam, try out the [interactive tour](https://tour.gleam.run/), or follow
    the [Syllabus on Exercism](https://exercism.org/tracks/gleam/concepts).
 
-Each section is broken into it's own module (a top level file named <module_name>.gleam, and optionally a folder named <module_name> containing files for submodules). You can read them in the order
+Each section is broken into its own module (a top level file named <module_name>.gleam, and optionally a folder named <module_name> containing files for submodules). You can read them in the order
 you like, but I recommend
 1. concurrency_primitives
 2. tasks

--- a/gleam.toml
+++ b/gleam.toml
@@ -15,7 +15,7 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 gleam_erlang = "~> 0.24"
-gleam_otp = "~> 0.9"
+gleam_otp = "0.16.1"
 prng = "~> 3.0"
 simplifile = ">= 1.7.0 and < 2.0.0"
 birl = ">= 1.5.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ packages = [
   { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_bitwise", version = "1.3.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "B36E1D3188D7F594C7FD4F43D0D2CE17561DE896202017548578B16FE1FE9EFC" },
   { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
-  { name = "gleam_otp", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5FADBBEC5ECF3F8B6BE91101D432758503192AE2ADBAD5602158977341489F71" },
+  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
   { name = "gleam_stdlib", version = "0.35.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5443EEB74708454B65650FEBBB1EF5175057D1DEC62AEA9D7C6D96F41DA79152" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "prng", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "C78A80DE41469A0BB1AB3B0B0610CCE5DB70C5659A540E2E0E6C54FA38134290" },
@@ -15,9 +15,9 @@ packages = [
 ]
 
 [requirements]
-birl = { version = ">= 1.5.0 and < 2.0.0"}
+birl = { version = ">= 1.5.0 and < 2.0.0" }
 gleam_erlang = { version = "~> 0.24" }
-gleam_otp = { version = "~> 0.9" }
+gleam_otp = { version = "0.16.1" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 prng = { version = "~> 3.0" }

--- a/src/actors/process_pool.gleam
+++ b/src/actors/process_pool.gleam
@@ -1,0 +1,57 @@
+import gleam/erlang/process
+import gleam/list
+import gleam/otp/actor
+
+pub type Pool(a) = process.Subject(Msg(a))
+
+pub type PoolError
+
+// Spin up a process pool.
+pub fn start_pool(max_concurrent_processes: Int) -> Result(Pool(a), actor.StartError) {
+  let init_state = State(max: max_concurrent_processes, process_count: 0, backlog: [])
+  actor.start(init_state, handle_msg)
+}
+
+// Do a task when there's availability and send me the result when it's done.
+pub fn do_when_available(pool: Pool(a), send_result: fn(a) -> Nil, task: fn() -> a) {
+  actor.send(pool, DoWhenAvailable(send_result:, task:))
+}
+
+pub fn shutdown(pool: Pool(a)) {
+    actor.send(pool, Shutdown)
+}
+
+pub opaque type Msg(a) {
+  DoWhenAvailable(send_result: fn(a) -> Nil, task: fn() -> a)
+  TaskComplete
+  Shutdown
+}
+
+type State {
+  State(max: Int, process_count: Int, backlog: List(fn() -> Nil))
+}
+
+fn handle_msg(msg: Msg(a), state: State) -> actor.Next(Msg(a), State) {
+  // Go through the queues backlog and fire off all the tasks we have room for
+  // in separate processes
+  let available = state.max - state.process_count
+  let work = list.take(state.backlog, up_to: available)
+  let state = State(..state, backlog: list.drop(state.backlog, available))
+
+  work
+  |> list.each(fn(work) {
+    let self = process.new_subject()
+    use <- process.start(linked: False)
+    work()
+    process.send(self, TaskComplete)
+  })
+
+  case msg {
+    DoWhenAvailable(send_result:, task:) ->
+      actor.continue(
+        State(..state, backlog: [fn() { send_result(task()) }, ..state.backlog]),
+      )
+    TaskComplete -> actor.continue(State(..state, process_count: state.process_count - 1))
+    Shutdown -> actor.Stop(process.Normal)
+  }
+}

--- a/src/concurrency_primitives.gleam
+++ b/src/concurrency_primitives.gleam
@@ -41,7 +41,7 @@ pub fn main() {
 
   // Note: If you've ever dabbled in Erlang/Elixir concurrency tutorials, you may be used
   // to sending messages to a pid directly. In Gleam, we use subjects, which 
-  // have a few advantadges over process ids:
+  // have a few advantages over process ids:
   // - They are generic over the message type, so we get type safe messages.
   // - You can have multiple per process. You can use multiple subjects to
   //   decouple the order in which messages are sent from the order in which they
@@ -81,7 +81,7 @@ pub fn main() {
   // the results, you'll want the `Task` module. It's great for the dead simple
   // "do this somewhere else and I'll let you know when I need it" case.
   //
-  // Before you run off reading those sections though, lets discuss subjects a 
+  // Before you run off reading those sections though, let's discuss subjects a 
   // bit more.
 
   let subject: Subject(String) = process.new_subject()
@@ -89,7 +89,7 @@ pub fn main() {
   // A subject works a bit like a mailbox. You can send messages
   // to it from any process. You can only receive messages
   // from it in the process that created it. 
-  // Under the hood, every erlang process has it's own mailbox.
+  // Under the hood, every erlang process has its own mailbox.
   // Subjects help us organize that mailbox, but you can't swap 
   // mailboxes with your neighbor.
 
@@ -101,7 +101,7 @@ pub fn main() {
   let assert Ok("hello from some rando process") =
     process.receive(subject, 1000)
 
-  // Notice that the subjects type is `Subject(String)`. Subjects are generic
+  // Notice that the subject's type is `Subject(String)`. Subjects are generic
   // over the type of message they can send/receive.
   // This is nice because the type system will help us ensure that we're not sending/receiving
   // the wrong type of message, and we can do less runtime checking than in a dynamic language.

--- a/src/supervisors.gleam
+++ b/src/supervisors.gleam
@@ -8,7 +8,7 @@
 //// Pretty straightforward, workers do work, supervisors supervise.
 //// 
 //// Ok, why is this good? 
-//// The propoganda goes like this:
+//// The propaganda goes like this:
 //// 
 //// -----------------------------------------------------------------------------------------
 //// 
@@ -70,7 +70,7 @@ pub fn main() {
   let game = supervisor.worker(duckduckgoose.start(_, parent_subject))
 
   // The supervisor API is really simple. All a supervisor needs is a function
-  // with which to intialize itself.
+  // with which to initialize itself.
   // There's a `supervisor.start_spec` function as well for tuning the 
   // restart frequency and the initial state to pass to children.
 

--- a/src/supervisors/a_shit_actor.gleam
+++ b/src/supervisors/a_shit_actor.gleam
@@ -30,7 +30,7 @@ import prng/random
 /// provide a startup function to produce the initial state,
 /// instead of simply providing the initial state directly.
 /// 
-/// We'll take advantadge of getting the chance to compute
+/// We'll take advantage of getting the chance to compute
 /// things on the new process to send ourselves back a subject
 /// for the actor.
 /// 
@@ -69,7 +69,7 @@ pub fn start(
     // waiting forever for the actor to start.
     init_timeout: 1000,
     // This is the function that will be called when the actor
-    // get's sent a message. We'll define it below.
+    // gets sent a message. We'll define it below.
     loop: handle_message,
   ))
 }

--- a/src/tasks.gleam
+++ b/src/tasks.gleam
@@ -112,7 +112,7 @@ pub fn main() {
 }
 
 // This is our base linear implementation for comparison. Hopefully it makes sense.
-// We fold over the list and for each codepoint we increment it's value in the list.
+// We fold over the list and for each codepoint we increment its value in the list.
 fn linear_letter_frequency(input: List(UtfCodepoint)) -> Dict(UtfCodepoint, Int) {
   use acc, letter <- list.fold(input, dict.new())
   use entry <- dict.update(acc, update: letter)
@@ -154,7 +154,7 @@ fn parallel_letter_frequency(
   }
 }
 
-// This is just a little timer function to help use see the results of our work.
+// This is just a little timer function to help us see the results of our work.
 fn time(name: String, f: fn() -> a) -> a {
   let start = birl.now()
   let x = f()


### PR DESCRIPTION
- Fix apostrophe errors in possessive forms (its vs it's)
- Fix spelling errors (propoganda, advantadge, thingss, intialize, etc.)
- Fix spacing issues in README.md (ALOT -> A LOT)