### PR TITLE
Fix typos in Gleam code files

### DIFF
--- a/src/actors/pantry.gleam
+++ b/src/actors/pantry.gleam
@@ -75,7 +75,7 @@ pub type Message {
 // holds state in its arguments, receives a message, possibly does some work or send messages back to other processes, 
 // and then calls itself with some new state. The `actor.Next` type is just an abstraction over that pattern.
 //
-// In fact, take a look at [it's definition](https://hexdocs.pm/gleam_otp/gleam/otp/actor.html#Next) 
+// In fact, take a look at [its definition](https://hexdocs.pm/gleam_otp/gleam/otp/actor.html#Next) 
 // and you'll see what I mean.
 fn handle_message(
   message: Message,

--- a/src/concurrency_primitives.gleam
+++ b/src/concurrency_primitives.gleam
@@ -41,7 +41,7 @@ pub fn main() {
 
   // Note: If you've ever dabbled in Erlang/Elixir concurrency tutorials, you may be used
   // to sending messages to a pid directly. In Gleam, we use subjects, which 
-  // have a few advantadges over process ids:
+  // have a few advantages over process ids:
   // - They are generic over the message type, so we get type safe messages.
   // - You can have multiple per process. You can use multiple subjects to
   //   decouple the order in which messages are sent from the order in which they

--- a/src/supervisors/a_shit_actor.gleam
+++ b/src/supervisors/a_shit_actor.gleam
@@ -69,7 +69,7 @@ pub fn start(
     // waiting forever for the actor to start.
     init_timeout: 1000,
     // This is the function that will be called when the actor
-    // get's sent a message. We'll define it below.
+    // gets sent a message. We'll define it below.
     loop: handle_message,
   ))
 }

--- a/src/tasks.gleam
+++ b/src/tasks.gleam
@@ -85,7 +85,7 @@ pub fn main() {
   // appears. We use a list of codepoints instead of a string because dealing with graphemes 
   // properly just distracts from the point of this exercise.
   
-  // Sidenote: If Gleam error handling is confusing for you, I've written [a short blog
+  // Side note: If Gleam error handling is confusing for you, I've written [a short blog
   // post on the subject](https://www.benjaminpeinhardt.com/error-handling-in-gleam/)
   use workload <- result.try(simplifile.read("./src/tasks/king_james_bible.txt"))
   let workload = string.to_utf_codepoints(workload)


### PR DESCRIPTION
## Summary
- Fixed possessive "its" in pantry.gleam
- Corrected "advantages" spelling in concurrency_primitives.gleam
- Fixed apostrophe in "gets" in a_shit_actor.gleam
- Changed "Sidenote" to "Side note" in tasks.gleam

## Test plan
No tests needed for minor typo fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)