### PR TITLE
Modify this tutorial to support gleam_otp v1.0.0 and gleam_erlang v1.2.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,11 +13,11 @@ version = "1.0.0"
 # https://gleam.run/writing-gleam/gleam-toml/. 
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = "~> 0.24"
-gleam_otp = "~> 0.9"
-prng = "~> 3.0"
-simplifile = ">= 1.7.0 and < 2.0.0"
+gleam_stdlib = "~> 0.61 or ~> 1.0"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
+prng = "~> 4.0.1"
+simplifile = ">= 2.3.0 and < 3.0.0"
 birl = ">= 1.5.0 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,23 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "23BFE5AB0D7D9E4ECC5BB89B7ABDDF8E976D98C65D2E173D116E6AAFBF24E633" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
+  { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_bitwise", version = "1.3.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "B36E1D3188D7F594C7FD4F43D0D2CE17561DE896202017548578B16FE1FE9EFC" },
-  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
-  { name = "gleam_otp", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5FADBBEC5ECF3F8B6BE91101D432758503192AE2ADBAD5602158977341489F71" },
-  { name = "gleam_stdlib", version = "0.35.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5443EEB74708454B65650FEBBB1EF5175057D1DEC62AEA9D7C6D96F41DA79152" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "prng", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "C78A80DE41469A0BB1AB3B0B0610CCE5DB70C5659A540E2E0E6C54FA38134290" },
-  { name = "ranger", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "28E615AE7590ED922AF1510DDF606A2ECBBC2A9609AF36D412EDC925F06DFD20" },
-  { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
+  { name = "gleam_stdlib", version = "0.61.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3DC407D6EDA98FCE089150C11F3AD892B6F4C3CA77C87A97BAE8D5AB5E41F331" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "prng", version = "4.0.1", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib", "gleam_yielder"], otp_app = "prng", source = "hex", outer_checksum = "695AB70E4BE713042062E901975FC08D1EC725B85B808D4786A14C406ADFBCF1" },
+  { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
+  { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
 ]
 
 [requirements]
-birl = { version = ">= 1.5.0 and < 2.0.0"}
-gleam_erlang = { version = "~> 0.24" }
-gleam_otp = { version = "~> 0.9" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+birl = { version = ">= 1.5.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = "~> 0.61 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
-prng = { version = "~> 3.0" }
-simplifile = { version = ">= 1.7.0 and < 2.0.0" }
+prng = { version = "~> 4.0.1" }
+simplifile = { version = ">= 2.3.0 and < 3.0.0" }

--- a/src/actors.gleam
+++ b/src/actors.gleam
@@ -22,7 +22,8 @@ pub fn main() {
 
   // In a real application, `open_pantry` might get the current contents of the pantry from
   // a database, but for this example the pantry will always start out empty
-  let assert Ok(pantry) = pantry.new()
+  let assert Ok(started) = pantry.new()
+  let pantry = started.data
 
   // Trying to remove an item from an empty pantry should return an error
   let assert Error(_) = pantry.take_item(pantry, "flour")

--- a/src/actors/pantry.gleam
+++ b/src/actors/pantry.gleam
@@ -24,8 +24,8 @@ const timeout: Int = 5000
 /// Create a new pantry actor.
 /// If the actor starts successfully, we get back an
 /// `Ok(subject)` which we can use to send messages to the actor.
-pub fn new() -> Result(Subject(Message), actor.StartError) {
-  actor.start(set.new(), handle_message)
+pub fn new() -> Result(actor.Started(Subject(Message)), actor.StartError) {
+  actor.new(set.new()) |> actor.on_message(handle_message) |> actor.start()
 }
 
 /// Add an item to the pantry.
@@ -43,7 +43,7 @@ pub fn take_item(pantry: Subject(Message), item: String) -> Result(String, Nil) 
   //
   // Also, since we need to wait for a response, we pass a timeout as the last argument so we don't get stuck
   // waiting forever if our actor process gets struck by lightning or something.
-  actor.call(pantry, TakeItem(_, item), timeout)
+  actor.call(pantry, timeout, TakeItem(_, item))
 }
 
 /// Close the pantry.
@@ -78,14 +78,14 @@ pub type Message {
 // In fact, take a look at [its definition](https://hexdocs.pm/gleam_otp/gleam/otp/actor.html#Next) 
 // and you'll see what I mean.
 fn handle_message(
-  message: Message,
   pantry: Set(String),
-) -> actor.Next(Message, Set(String)) {
+  message: Message,
+) -> actor.Next(Set(String), Message) {
   // We pattern match on the message to decide what to do.
   case message {
     // This type of message will be in most actors, it's worth just sticking 
     // at the top.
-    Shutdown -> actor.Stop(process.Normal)
+    Shutdown -> actor.stop()
 
     // We're adding an item to the pantry. We don't need to reply to anyone, so we just
     // send the new state back to the actor to continue with.

--- a/src/rescue_ffi.erl
+++ b/src/rescue_ffi.erl
@@ -1,0 +1,10 @@
+-module(rescue_ffi).
+-export([rescue/1]).
+
+rescue(F) ->
+    try {ok, F()}
+    catch
+        throw:X -> {error, {thrown, X}};
+        error:X -> {error, {errored, X}};
+        exit:X -> {error, {exited, X}}
+    end.

--- a/src/supervisors.gleam
+++ b/src/supervisors.gleam
@@ -98,23 +98,20 @@ fn play_game(
     // Base Case, recess is over
     0 -> Nil
     _ -> {
-      let xs = duckduckgoose.play_game(game_subject)
-      // The result of process receive tells us whether
-      // we are a goose or a duck
-      case process.receive(parent_subject, 50) {
-        // It's a duck because there's no message in our inbox
-        Error(Nil) -> {
-          io.println(xs)
+      case duckduckgoose.play_game(game_subject) {
+        Ok(msg) -> {
+          io.println(msg)
           // We're just a normal old duck, so we keep playing
           play_game(parent_subject, game_subject, n - 1)
         }
-        // The supervisor should restart our actor for us,
-        // but it'll be on a different process now! Don't 
-        // worry though, the game's init function should
-        // send us a new subject to use.
-        Ok(new_game_subject) -> {
-          io.println(xs)
-          io.println("Oh no, a goose crashed our actor!")
+        Error(_) -> {
+          io.println("Oh no, it's a fucking goose!!!!")
+          // The supervisor should restart our actor for us,
+          // but it'll be on a different process now! Don't 
+          // worry though, the game's init function should
+          // send us a new subject to use.
+          let assert Ok(new_game_subject) =
+            process.receive(parent_subject, 1000)
           // Keep playing the game with the new subject
           play_game(parent_subject, new_game_subject, n - 1)
         }

--- a/src/supervisors.gleam
+++ b/src/supervisors.gleam
@@ -56,7 +56,6 @@
 import gleam/erlang/process.{type Subject}
 import gleam/io
 import gleam/otp/static_supervisor as supervisor
-import gleam/otp/supervision
 import supervisors/a_shit_actor as duckduckgoose
 
 pub fn main() {
@@ -68,7 +67,7 @@ pub fn main() {
   // us messages with on init. Remember, it needs to send us back a subject so we 
   // can talk to it directly.
   let parent_subject = process.new_subject()
-  let worker = duckduckgoose.start(parent_subject) |> supervision.worker()
+  let worker = duckduckgoose.start(parent_subject)
 
   // # times we'll play supervisors.play_game
   let n_times = 100

--- a/src/supervisors/a_shit_actor.gleam
+++ b/src/supervisors/a_shit_actor.gleam
@@ -24,7 +24,7 @@ import prng/random
 /// directly. Instead, we'll have to send the subject
 /// to the parent process when the actor starts up.
 /// 
-/// The `actor.start_spec` function gives us more fine-grained
+/// The `actor.new_with_initialiser` function gives us more fine-grained
 /// control over how the actor gets created. We get to
 /// provide a startup function to produce the initial state,
 /// instead of simply providing the initial state directly.
@@ -34,7 +34,7 @@ import prng/random
 /// for the actor.
 /// 
 /// This isn't a hack, it's the intended design. The subject
-/// produced by the `actor.start_spec` function is for the
+/// produced by the `actor.new_with_initialiser` function is for the
 /// supervisor to use, not for us to use directly.
 fn actor_child(init init, loop loop) {
   actor.new_with_initialiser(50, init)

--- a/src/supervisors/a_shit_actor.gleam
+++ b/src/supervisors/a_shit_actor.gleam
@@ -42,12 +42,15 @@ fn actor_child(init init, loop loop) {
   |> actor.start
 }
 
-pub fn start(parent_subject: Subject(Subject(Message))) {
+pub fn start(
+  parent_subject: Subject(Subject(Message)),
+) -> fn() -> Result(actor.Started(Nil), actor.StartError) {
   fn() {
     actor_child(
       init: fn(_) {
         let actor_subject = process.new_subject()
         process.send(parent_subject, actor_subject)
+        process.trap_exits(True)
         let selector =
           process.new_selector()
           |> process.select(actor_subject)
@@ -71,7 +74,7 @@ pub fn shutdown(subject: Subject(Message)) -> Nil {
 /// This is how we play the game.
 /// We are at the whim of the child as to whether we are a 
 /// humble duck or the mighty goose.
-pub fn play_game(subject: Subject(Message)) {
+pub fn play_game(subject: Subject(Message)) -> String {
   // -> Result(String, process.CallError(String)) {
   let msg_generator = random.weighted(#(90.0, Duck), [#(10.0, Goose)])
   let msg = random.random_sample(msg_generator)

--- a/src/tasks.gleam
+++ b/src/tasks.gleam
@@ -1,5 +1,11 @@
 //// Tasks are one off processes meant to easily make synchronous work async.
 //// They're really straightforward to use, just fire them off and check back later.
+//// The gleam_otp.tasks (0.16.1) module was not upgraded to gleam_otp 1.0.0.
+//// I suspect the the thinking is that, because they are mereil conveniences for
+//// spawning and awaiting tasks, it should not be part of gleam_otp
+//// I suspect the the thinking is that, because tasks are merely conveniences for
+//// spawning and awaiting tasks, it should not be part of gleam_otp. Consequently,
+//// I've taken the liberpy of porting of the module myself in tasks/task.gleam
 
 import birl
 import birl/duration

--- a/src/tasks/task.gleam
+++ b/src/tasks/task.gleam
@@ -1,0 +1,455 @@
+//// A task is a kind of process that computes a value and then sends the result back
+//// to its parent. Commonly multiple tasks are used to compute multiple things at
+//// once.
+////
+//// If you do not care to receive a result back at the end then you should not
+//// use this module, `actor` or `process` are likely more suitable.
+////
+//// ```gleam
+//// let task = task.async(fn() { do_some_work() })
+//// let value = do_some_other_work()
+//// value + task.await(task, 100)
+//// ```
+////
+//// Tasks spawned with async can be awaited on by their caller process (and
+//// only their caller) as shown in the example above. They are implemented by
+//// spawning a process that sends a message to the caller once the given
+//// computation is performed.
+////
+//// There are some important things to consider when using tasks:
+////
+//// 1. If you are using async tasks, you must await a reply as they are always
+////    sent.
+////
+//// 2. Tasks link the caller and the spawned process. This means that,
+////    if the caller crashes, the task will crash too and vice-versa. This is
+////    on purpose: if the process meant to receive the result no longer
+////    exists, there is no purpose in completing the computation.
+////
+//// 3. A task's callback function must complete by returning or panicking.
+////    It must not `exit` with the reason "normal".
+////
+//// This module is inspired by Elixir's [Task module][1].
+////
+//// [1]: https://hexdocs.pm/elixir/master/Task.html
+////
+
+import gleam/dict
+import gleam/dynamic.{type Dynamic}
+import gleam/erlang/process.{type Pid, type Selector, type Subject}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+
+pub opaque type Task(value) {
+  Task(owner: Pid, pid: Pid, subject: Subject(value))
+}
+
+// TODO: test
+/// Spawn a task process that calls a given function in order to perform some
+/// work. The result of this function is sent back to the parent and can be
+/// received using the `await` function.
+///
+/// See the top level module documentation for more information on async/await.
+///
+pub fn async(work: fn() -> value) -> Task(value) {
+  let owner = process.self()
+  let subject = process.new_subject()
+  let pid = process.spawn(fn() { process.send(subject, work()) })
+  Task(owner: owner, pid: pid, subject: subject)
+}
+
+pub type AwaitError {
+  Timeout
+  Exit(reason: Dynamic)
+}
+
+// We can only wait on a task if we are the owner of it so crash if we are
+// waiting on a task we don't own.
+fn assert_owner(task: Task(a)) -> Nil {
+  let self = process.self()
+  case task.owner == self {
+    True -> Nil
+    False ->
+      process.send_abnormal_exit(
+        self,
+        "awaited on a task that does not belong to this process",
+      )
+  }
+}
+
+// TODO: test
+/// Wait for the value computed by a task.
+///
+/// If the a value is not received before the timeout has elapsed then an error
+/// is returned.
+///
+pub fn try_await(task: Task(value), timeout: Int) -> Result(value, AwaitError) {
+  assert_owner(task)
+  let selector =
+    process.new_selector()
+    |> process.select(task.subject)
+  case process.selector_receive(selector, timeout) {
+    // The task process has sent back a value
+    Ok(x) -> Ok(x)
+
+    // The task process is alive but has not sent a value yet
+    Error(Nil) -> Error(Timeout)
+  }
+}
+
+/// Wait for the value computed by a task.
+///
+/// If the a value is not received before the timeout has elapsed or if the
+/// task process crashes then this function crashes.
+///
+pub fn await(task: Task(value), timeout: Int) -> value {
+  let assert Ok(value) = try_await(task, timeout)
+  value
+}
+
+/// Get the `Pid` for a task.
+///
+pub fn pid(task: Task(value)) -> Pid {
+  task.pid
+}
+
+/// Wait endlessly for the value computed by a task.
+///
+/// Be Careful! Like `try_await_forever`, this function does not return until
+/// there is a value to receive.
+///
+/// If the task process crashes then this function crashes.
+///
+pub fn await_forever(task: Task(value)) -> value {
+  assert_owner(task)
+  let selector =
+    process.new_selector()
+    |> process.select(task.subject)
+  process.selector_receive_forever(selector)
+}
+
+type Message2(t1, t2) {
+  M2FromSubject1(t1)
+  M2FromSubject2(t2)
+  M2Timeout
+}
+
+/// Wait for the values computed by multiple tasks.
+///
+/// For each task, if the a value is not received before the timeout has
+/// elapsed then an error is returned.
+///
+pub fn try_await2(
+  task1: Task(t1),
+  task2: Task(t2),
+  timeout: Int,
+) -> #(Result(t1, AwaitError), Result(t2, AwaitError)) {
+  assert_owner(task1)
+  assert_owner(task2)
+
+  let timeout_subject = process.new_subject()
+  let timer = process.send_after(timeout_subject, timeout, M2Timeout)
+
+  process.new_selector()
+  |> process.select_map(task1.subject, M2FromSubject1)
+  |> process.select_map(task2.subject, M2FromSubject2)
+  |> process.select(timeout_subject)
+  |> try_await2_loop(None, None, timer)
+}
+
+fn try_await2_loop(
+  selector: Selector(Message2(t1, t2)),
+  t1: Option(Result(t1, AwaitError)),
+  t2: Option(Result(t2, AwaitError)),
+  timer: process.Timer,
+) -> #(Result(t1, AwaitError), Result(t2, AwaitError)) {
+  case t1, t2 {
+    Some(t1), Some(t2) -> {
+      process.cancel_timer(timer)
+      #(t1, t2)
+    }
+
+    _, _ -> {
+      case process.selector_receive_forever(selector) {
+        // The task process has sent back a value
+        M2FromSubject1(x) -> {
+          let t1 = Some(Ok(x))
+          try_await2_loop(selector, t1, t2, timer)
+        }
+        M2FromSubject2(x) -> {
+          let t2 = Some(Ok(x))
+          try_await2_loop(selector, t1, t2, timer)
+        }
+
+        M2Timeout -> {
+          #(
+            option.unwrap(t1, Error(Timeout)),
+            option.unwrap(t2, Error(Timeout)),
+          )
+        }
+      }
+    }
+  }
+}
+
+type Message3(t1, t2, t3) {
+  M3FromSubject1(t1)
+  M3FromSubject2(t2)
+  M3FromSubject3(t3)
+  M3Timeout
+}
+
+/// Wait for the values computed by multiple tasks.
+///
+/// For each task, if the a value is not received before the timeout has
+/// elapsed then an error is returned.
+///
+pub fn try_await3(
+  task1: Task(t1),
+  task2: Task(t2),
+  task3: Task(t3),
+  timeout: Int,
+) -> #(Result(t1, AwaitError), Result(t2, AwaitError), Result(t3, AwaitError)) {
+  assert_owner(task1)
+  assert_owner(task2)
+  assert_owner(task3)
+
+  let timeout_subject = process.new_subject()
+  let timer = process.send_after(timeout_subject, timeout, M3Timeout)
+
+  process.new_selector()
+  |> process.select_map(task1.subject, M3FromSubject1)
+  |> process.select_map(task2.subject, M3FromSubject2)
+  |> process.select_map(task3.subject, M3FromSubject3)
+  |> process.select(timeout_subject)
+  |> try_await3_loop(None, None, None, timer)
+}
+
+fn try_await3_loop(
+  selector: Selector(Message3(t1, t2, t3)),
+  t1: Option(Result(t1, AwaitError)),
+  t2: Option(Result(t2, AwaitError)),
+  t3: Option(Result(t3, AwaitError)),
+  timer: process.Timer,
+) -> #(Result(t1, AwaitError), Result(t2, AwaitError), Result(t3, AwaitError)) {
+  case t1, t2, t3 {
+    Some(t1), Some(t2), Some(t3) -> {
+      process.cancel_timer(timer)
+      #(t1, t2, t3)
+    }
+
+    _, _, _ -> {
+      case process.selector_receive_forever(selector) {
+        // The task process has sent back a value
+        M3FromSubject1(x) -> {
+          let t1 = Some(Ok(x))
+          try_await3_loop(selector, t1, t2, t3, timer)
+        }
+        M3FromSubject2(x) -> {
+          let t2 = Some(Ok(x))
+          try_await3_loop(selector, t1, t2, t3, timer)
+        }
+        M3FromSubject3(x) -> {
+          let t3 = Some(Ok(x))
+          try_await3_loop(selector, t1, t2, t3, timer)
+        }
+
+        M3Timeout -> {
+          #(
+            option.unwrap(t1, Error(Timeout)),
+            option.unwrap(t2, Error(Timeout)),
+            option.unwrap(t3, Error(Timeout)),
+          )
+        }
+      }
+    }
+  }
+}
+
+type Message4(t1, t2, t3, t4) {
+  M4FromSubject1(t1)
+  M4FromSubject2(t2)
+  M4FromSubject3(t3)
+  M4FromSubject4(t4)
+  M4Timeout
+}
+
+/// Wait for the values computed by multiple tasks.
+///
+/// For each task, if the a value is not received before the timeout has
+/// elapsed then an error is returned.
+///
+pub fn try_await4(
+  task1: Task(t1),
+  task2: Task(t2),
+  task3: Task(t3),
+  task4: Task(t4),
+  timeout: Int,
+) -> #(
+  Result(t1, AwaitError),
+  Result(t2, AwaitError),
+  Result(t3, AwaitError),
+  Result(t4, AwaitError),
+) {
+  assert_owner(task1)
+  assert_owner(task2)
+  assert_owner(task3)
+
+  let timeout_subject = process.new_subject()
+  let timer = process.send_after(timeout_subject, timeout, M4Timeout)
+
+  process.new_selector()
+  |> process.select_map(task1.subject, M4FromSubject1)
+  |> process.select_map(task2.subject, M4FromSubject2)
+  |> process.select_map(task3.subject, M4FromSubject3)
+  |> process.select_map(task4.subject, M4FromSubject4)
+  |> process.select(timeout_subject)
+  |> try_await4_loop(None, None, None, None, timer)
+}
+
+fn try_await4_loop(
+  selector: Selector(Message4(t1, t2, t3, t4)),
+  t1: Option(Result(t1, AwaitError)),
+  t2: Option(Result(t2, AwaitError)),
+  t3: Option(Result(t3, AwaitError)),
+  t4: Option(Result(t4, AwaitError)),
+  timer: process.Timer,
+) -> #(
+  Result(t1, AwaitError),
+  Result(t2, AwaitError),
+  Result(t3, AwaitError),
+  Result(t4, AwaitError),
+) {
+  case t1, t2, t3, t4 {
+    Some(t1), Some(t2), Some(t3), Some(t4) -> {
+      process.cancel_timer(timer)
+      #(t1, t2, t3, t4)
+    }
+
+    _, _, _, _ -> {
+      case process.selector_receive_forever(selector) {
+        // The task process has sent back a value
+        M4FromSubject1(x) -> {
+          let t1 = Some(Ok(x))
+          try_await4_loop(selector, t1, t2, t3, t4, timer)
+        }
+        M4FromSubject2(x) -> {
+          let t2 = Some(Ok(x))
+          try_await4_loop(selector, t1, t2, t3, t4, timer)
+        }
+        M4FromSubject3(x) -> {
+          let t3 = Some(Ok(x))
+          try_await4_loop(selector, t1, t2, t3, t4, timer)
+        }
+        M4FromSubject4(x) -> {
+          let t4 = Some(Ok(x))
+          try_await4_loop(selector, t1, t2, t3, t4, timer)
+        }
+
+        M4Timeout -> {
+          #(
+            option.unwrap(t1, Error(Timeout)),
+            option.unwrap(t2, Error(Timeout)),
+            option.unwrap(t3, Error(Timeout)),
+            option.unwrap(t4, Error(Timeout)),
+          )
+        }
+      }
+    }
+  }
+}
+
+type Message(t) {
+  Message(from: Int, value: t)
+  MessageTimeout
+}
+
+/// Wait for the values computed by multiple tasks.
+///
+/// For each task, if the a value is not received before the timeout has
+/// elapsed then an error is returned.
+///
+pub fn try_await_all(
+  tasks: List(Task(t)),
+  timeout: Int,
+) -> List(Result(t, AwaitError)) {
+  let #(selector, tasks_count) = {
+    let acc = #(process.new_selector(), 0)
+    // We need to do a couple of things before we start listening:
+    // - we have to check the owner of every task
+    // - we have to count the tasks to know when we can stop waiting for results
+    // - we have to map each task's message to keep track of its position in the
+    //   original list
+    //
+    // Instead of iterating through the tasks list three times we do everything
+    // in a single fold that has to go through the list just once!
+    use #(selector, tasks_count), task, index <- list.index_fold(tasks, acc)
+    assert_owner(task)
+    let selector = process.select_map(selector, task.subject, Message(index, _))
+    #(selector, tasks_count + 1)
+  }
+
+  let timeout_subject = process.new_subject()
+  let timer = process.send_after(timeout_subject, timeout, MessageTimeout)
+  let selector = process.select(selector, timeout_subject)
+
+  try_await_all_loop(dict.new(), tasks_count, timer, selector)
+}
+
+fn try_await_all_loop(
+  values: dict.Dict(Int, Result(b, AwaitError)),
+  tasks_count: Int,
+  timer: process.Timer,
+  selector: Selector(Message(b)),
+) -> List(Result(b, AwaitError)) {
+  case dict.size(values) == tasks_count {
+    // If there's no more values to receive then we can return the list...
+    True -> {
+      process.cancel_timer(timer)
+      dict_to_list(values, tasks_count, Error(Timeout))
+    }
+    // Otherwise we wait to receive another message (or the timeout) from one of
+    // the tasks.
+    False ->
+      case process.selector_receive_forever(selector) {
+        MessageTimeout -> dict_to_list(values, tasks_count, Error(Timeout))
+        Message(from: index, value:) -> {
+          let values = dict.insert(values, index, Ok(value))
+          try_await_all_loop(values, tasks_count, timer, selector)
+        }
+      }
+  }
+}
+
+/// Given a dict returns a list with size `sized` where each item at index `i`
+/// is `dict.get(dict, i) |> result.unwrap(default)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// dict.from_list([#(1, "a"), #(4, "b")])
+/// |> dict_to_list(5, " ")
+/// // -> [" ", "a", " ", " ", "b"]
+/// ```
+///
+fn dict_to_list(dict: dict.Dict(Int, a), sized: Int, default: a) -> List(a) {
+  dict_to_list_loop(dict, default, sized - 1, [])
+}
+
+fn dict_to_list_loop(
+  dict: dict.Dict(Int, a),
+  default: a,
+  index: Int,
+  list: List(a),
+) -> List(a) {
+  case index < 0 {
+    True -> list
+    False -> {
+      let value = case dict.get(dict, index) {
+        Error(_) -> default
+        Ok(value) -> value
+      }
+      dict_to_list_loop(dict, default, index - 1, [value, ..list])
+    }
+  }
+}


### PR DESCRIPTION
Your original tutorial, based on `gleam_otp v0.16.1`, helped me considerably in learning how to accomplish OTP in Gleam. So, I thought what better way to pay it forward than upgrading it to support `gleam_otp v1.0.0`. Note that  `gleam_otp.tasks` is no longer present in version 1.0.0, so I ported it myself and placed it under `src/tasks/task.gleam`.

Besides porting `gleam_otb.tasks`,  changes in your `actors` and `concurrency_primitives` module were relatively minor.  However, supervisors were a different story. Due to the removal of `process.try_call` in `gleam_erlang v1.0.0`, I had to change the signature of the `a_shit_actor.play_game` from `Result(String, process.CallError(String))` to `Result(String, Nil)` and consequently, whenever a goose is selected, the`a_shit_actor.handle_message` sends an `Error(Nil)` message to the supervisor before executing`process.stop_abnormal`.  This ensures the caller isn't leaking memory by dropping the message before stopping.